### PR TITLE
Optimizations and more convenient functions

### DIFF
--- a/bottom/bottom.go
+++ b/bottom/bottom.go
@@ -1,91 +1,262 @@
 package bottom
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
+	"fmt"
+	"io"
 	"strings"
+	"unicode/utf8"
+
+	"github.com/nihaals/bottom-go/bottom/internal/unsafebytes"
 )
 
-type character struct {
-	value byte
-	char  string
+const (
+	char0   = "\u2764\uFE0F"
+	char1   = '\u002C'
+	char5   = '\U0001F97A'
+	char10  = '\U00002728'
+	char50  = '\U0001F496'
+	char200 = '\U0001FAC2'
+
+	sectionSeparator = "\U0001F449\U0001F448"
+)
+
+// characterValues looks up known runes; it returns 0 for unknown runes.
+func characterValues(s rune) byte {
+	switch s {
+	case char1:
+		return 1
+	case char5:
+		return 5
+	case char10:
+		return 10
+	case char50:
+		return 50
+	case char200:
+		return 200
+	default:
+		return 0 // unknown
+	}
 }
 
-var zeroCharacter = character{value: 0, char: "\u2764\uFE0F"}
-var characterValues = [5]character{
-	{value: 200, char: "\U0001FAC2"},
-	{value: 50, char: "\U0001F496"},
-	{value: 10, char: "\U00002728"},
-	{value: 5, char: "\U0001F97A"},
-	{value: 1, char: "\u002C"},
+// valueCharacterBases looks up known values for the corresponding runes; it
+// gives 0 for unknown values.
+var valueCharacterBases = [255]string{
+	1:   string(char1),
+	5:   string(char5),
+	10:  string(char10),
+	50:  string(char50),
+	200: string(char200),
 }
 
-const sectionSeparator = "\U0001F449\U0001F448"
+// valueCharacters looks up all possible bytes for the corresponding bottom
+// runes.
+var valueCharacters = calculateValueCharacters()
 
-// Encode encodes a string in bottom
-func Encode(s string) (out string) {
-	for _, sChar := range []byte(s) {
-		if sChar == 0 {
-			out += zeroCharacter.char
-			continue
-		}
-		for sChar != 0 {
-			for _, char := range characterValues {
-				if sChar >= char.value {
-					sChar -= char.value
-					out += char.char
+func calculateValueCharacters() [255]string {
+	var values = []byte{200, 50, 10, 5, 1}
+	var valueCharacters = [255]string{0: char0}
+	var buf bytes.Buffer
+
+	for i := byte(1); i < 255; i++ {
+		char := i
+		for char > 0 {
+			for _, v := range values {
+				if char >= v {
+					char -= v
+					buf.WriteString(valueCharacterBases[v])
 					break
 				}
 			}
 		}
-		out += sectionSeparator
+
+		buf.WriteString(sectionSeparator)
+		valueCharacters[i] = buf.String()
+		buf.Reset()
 	}
-	return
+
+	return valueCharacters
 }
 
-// Validate validates a bottom string
+// Encode encodes a string in bottom
+func Encode(s string) string {
+	out := make([]byte, EncodedLen(s))
+	sum := 0
+
+	for _, sChar := range []byte(s) {
+		sum += copy(out[sum:], valueCharacters[sChar])
+	}
+
+	return unsafebytes.String(out)
+}
+
+// EncodedLen returns the length of the encoded string in exact.
+func EncodedLen(s string) int {
+	var l int
+	for _, sChar := range []byte(s) {
+		l += len(valueCharacters[sChar])
+	}
+
+	return l
+}
+
+// EncodeTo encodes the given string into the writer.
+func EncodeTo(out io.StringWriter, s string) (int, error) {
+	var sum int
+
+	for _, sChar := range []byte(s) {
+		n, err := out.WriteString(valueCharacters[sChar])
+		if err != nil {
+			return sum, err
+		}
+
+		sum += n
+	}
+
+	return sum, nil
+}
+
+// Validate validates a bottom string.
 func Validate(bottom string) bool {
-	if !strings.HasSuffix(bottom, sectionSeparator) {
-		return false
-	}
-	bottom = strings.Replace(bottom, sectionSeparator, "", -1)
-	for _, inputCharRune := range bottom {
-		inputChar := string(inputCharRune)
-		if inputChar == zeroCharacter.char {
-			continue
-		}
-		valid := false
-		for _, char := range characterValues {
-			if char.char == inputChar {
-				valid = true
-				break
-			}
-		}
-		if !valid {
-			return false
-		}
-	}
-	return true
+	return DecodedLen(bottom) > -1
 }
 
-// Decode decodes a bottom string
-func Decode(b string) (out string, err error) {
-	if !Validate(b) {
-		return "", errors.New("Invalid bottom text")
+// DecodedLen validates the given bottom string and returns the calculated
+// length. It returns -1 if the given bottom string is invalid.
+func DecodedLen(bottom string) int {
+	if !strings.HasSuffix(bottom, sectionSeparator) {
+		return -1
 	}
-	b = b[:len(b)-2]
-	o := []byte{}
-	for _, outCharBlock := range strings.Split(b, sectionSeparator) {
-		var sum byte = 0
-		for _, bottomCharRune := range outCharBlock {
-			bottomChar := string(bottomCharRune)
-			for _, char := range characterValues {
-				if char.char == bottomChar {
-					sum += char.value
-				}
+
+	// We used to trim the sectionSeparator suffix here, but since our current
+	// method of Index seeking does not account for the last section, we don't
+	// need to trim it.
+	//
+	// This assumption is validated by the above HasSuffix check.
+
+	var length, sum int
+
+	for {
+		m := strings.Index(bottom, sectionSeparator)
+		if m < 0 {
+			break
+		}
+
+		sum = 0
+
+		for _, r := range bottom[:m] {
+			v := characterValues(r)
+			if v == 0 {
+				return -1
+			}
+
+			// overflow check
+			if sum += int(v); sum > 0xFF {
+				return -1
 			}
 		}
-		o = append(o, sum)
+
+		length++
+		bottom = bottom[m+len(sectionSeparator):]
 	}
-	out = string(o)
+
+	return length
+}
+
+// Decode verifies and decodes a bottom string. An error is returned if the
+// verification fails.
+func Decode(bottom string) (string, error) {
+	l := DecodedLen(bottom)
+	if l == -1 {
+		return "", errors.New("invalid bottom text")
+	}
+
+	buf := make([]byte, l)
+
+	var i int
+	for i < l {
+		m := strings.Index(bottom, sectionSeparator)
+		if m < 0 {
+			break
+		}
+
+		buf[i] = sumByte(bottom[:m])
+		bottom = bottom[m+len(sectionSeparator):]
+		i++
+	}
+
+	return unsafebytes.String(buf), nil
+}
+
+// DecodeTo decodes the given bottom string into the given byte writer.
+func DecodeTo(w io.ByteWriter, bottom string) error {
+	for {
+		m := strings.Index(bottom, sectionSeparator)
+		if m < 0 {
+			break
+		}
+
+		if err := w.WriteByte(sumByte(bottom[:m])); err != nil {
+			return err
+		}
+
+		bottom = bottom[m+len(sectionSeparator):]
+	}
+
+	return nil
+}
+
+func sumByte(part string) (sum byte) {
+	for _, r := range part {
+		sum += characterValues(r)
+	}
 	return
+}
+
+// DecodeFrom decodes from a src reader.
+func DecodeFrom(w io.ByteWriter, src io.Reader) error {
+	scanner := bufio.NewScanner(src)
+	scanner.Split(scanUntilSeparator)
+
+	var sum byte
+	for scanner.Scan() {
+		sum = 0
+		bytes := scanner.Bytes()
+
+		for len(bytes) > 0 {
+			r, sz := utf8.DecodeRune(bytes)
+			if sz == -1 {
+				return fmt.Errorf("invalid bytes %q", bytes)
+			}
+
+			sum += characterValues(r)
+			bytes = bytes[sz:]
+		}
+
+		if err := w.WriteByte(sum); err != nil {
+			return err
+		}
+	}
+
+	return scanner.Err()
+}
+
+func scanUntilSeparator(data []byte, eof bool) (int, []byte, error) {
+	if eof && len(data) == 0 {
+		return 0, nil, nil
+	}
+
+	if i := bytes.Index(data, []byte(sectionSeparator)); i >= 0 {
+		return i + len(sectionSeparator), data[:i], nil
+	}
+
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if eof {
+		return len(data), data, nil
+	}
+
+	// Request more data.
+	return 0, nil, nil
 }

--- a/bottom/bottom_test.go
+++ b/bottom/bottom_test.go
@@ -1,12 +1,16 @@
-package bottom_test
+package bottom
 
 import (
+	"strings"
 	"testing"
-
-	"github.com/nihaals/bottom-go/bottom"
 )
 
-var testCases = [][]string{
+type testCase struct {
+	in  string
+	out string
+}
+
+var testCases = []testCase{
 	{"test", "💖💖✨🥺,👉👈💖💖,👉👈💖💖✨🥺👉👈💖💖✨🥺,👉👈"},
 	{"Hello World!", "💖✨✨,,👉👈💖💖,👉👈💖💖🥺,,,👉👈💖💖🥺,,,👉👈💖💖✨,👉👈✨✨✨,,👉👈💖✨✨✨🥺,,👉👈💖💖✨,👉👈💖💖✨,,,,👉👈💖💖🥺,,,👉👈💖💖👉👈✨✨✨,,,👉👈"},
 	{"がんばれ", "🫂✨✨🥺,,👉👈💖💖✨✨🥺,,,,👉👈💖💖✨✨✨✨👉👈🫂✨✨🥺,,👉👈💖💖✨✨✨👉👈💖💖✨✨✨✨🥺,,👉👈🫂✨✨🥺,,👉👈💖💖✨✨🥺,,,,👉👈💖💖💖✨✨🥺,👉👈" +
@@ -16,21 +20,117 @@ var testCases = [][]string{
 
 func TestEncode(t *testing.T) {
 	for _, c := range testCases {
-		if out := bottom.Encode(c[0]); out != c[1] {
-			t.Errorf("expected: \"%v\", got \"%v\"", c[1], out)
-		}
+		t.Run(c.in, func(t *testing.T) {
+			if out := Encode(c.in); out != c.out {
+				t.Fatalf("expected %q, got %q", c.out, out)
+			}
+		})
 	}
 }
 
 func TestDecode(t *testing.T) {
 	for _, c := range testCases {
-		out, err := bottom.Decode(c[1])
-		if err != nil {
-			t.Error(err)
-		}
+		t.Run(c.in, func(t *testing.T) {
+			o, err := Decode(c.out)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		if out != c[0] {
-			t.Errorf("expected: \"%v\", got \"%v\"", c[0], out)
-		}
+			if o != c.in {
+				t.Fatalf("expected %q, got %q", c.in, o)
+			}
+		})
 	}
 }
+
+func TestDecodeTo(t *testing.T) {
+	for _, c := range testCases {
+		t.Run(c.in, func(t *testing.T) {
+			var buf strings.Builder
+
+			if err := DecodeTo(&buf, c.out); err != nil {
+				t.Fatal(err)
+			}
+
+			if buf.String() != c.in {
+				t.Fatalf("expected %q, got %q", c.in, buf.String())
+			}
+		})
+	}
+}
+
+func TestDecodeFrom(t *testing.T) {
+	for _, c := range testCases {
+		t.Run(c.in, func(t *testing.T) {
+			var dst strings.Builder
+
+			if err := DecodeFrom(&dst, strings.NewReader(c.out)); err != nil {
+				t.Fatal(err)
+			}
+
+			if dst.String() != c.in {
+				t.Fatalf("expected %q, got %q", c.in, dst.String())
+			}
+		})
+	}
+}
+
+func TestDecodedLen(t *testing.T) {
+	for _, c := range testCases {
+		t.Run(c.in, func(t *testing.T) {
+			var dst strings.Builder
+
+			// use DecodeTo to skip the length check
+			_ = DecodeTo(&dst, c.out)
+			out, _ := Decode(c.out)
+
+			if dst.Len() != len(out) {
+				t.Errorf("expected len %d, got %d", len(out), dst.Len())
+			}
+		})
+	}
+}
+
+func BenchmarkEncode(b *testing.B) {
+	testCase := testCases[2]
+	b.SetBytes(int64(len(testCase.in)))
+
+	for i := 0; i < b.N; i++ {
+		_ = Encode(testCase.in)
+	}
+}
+
+func BenchmarkEncodeTo(b *testing.B) {
+	testCase := testCases[2]
+	b.SetBytes(int64(len(testCase.out)))
+
+	var w noopWriter
+	for i := 0; i < b.N; i++ {
+		_, _ = EncodeTo(w, testCase.out)
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	testCase := testCases[2]
+	b.SetBytes(int64(len(testCase.out)))
+
+	for i := 0; i < b.N; i++ {
+		_, _ = Decode(testCase.out)
+	}
+}
+
+func BenchmarkDecodeFrom(b *testing.B) {
+	testCase := testCases[2]
+	b.SetBytes(int64(len(testCase.out)))
+
+	var w noopWriter
+	for i := 0; i < b.N; i++ {
+		_ = DecodeFrom(w, strings.NewReader(testCase.out))
+	}
+}
+
+type noopWriter struct{}
+
+func (noopWriter) WriteByte(c byte) error { return nil }
+
+func (noopWriter) WriteString(s string) (int, error) { return len(s), nil }

--- a/bottom/internal/unsafebytes/unsafebytes.go
+++ b/bottom/internal/unsafebytes/unsafebytes.go
@@ -1,0 +1,9 @@
+package unsafebytes
+
+import "unsafe"
+
+// String converts a byte slice to a string in an unsafe, non-copy fashion. It
+// works similarly to strings.Builder's String method.
+func String(bytes []byte) string {
+	return *(*string)(unsafe.Pointer(&bytes))
+}


### PR DESCRIPTION
This pull request adds a range of new and idiomatic functions:

    func DecodeFrom(w io.ByteWriter, src io.Reader) error
    func DecodeTo(w io.ByteWriter, bottom string) error
    func DecodedLen(bottom string) int
    func EncodeTo(out io.StringWriter, s string) (int, error)
    func EncodedLen(s string) int

In addition to these additions (whoops), the overall implementation is also a lot more optimized. The new benchmarks for these changes yield

```
BenchmarkEncode-8         798862          1491 ns/op
BenchmarkDecode-8   	  379851	      3387 ns/op
```

For reference, before these changes, they were

```
BenchmarkEncode-8          91110         11410 ns/op
BenchmarkDecode-8         115258         10075 ns/op
```