### PR TITLE
Prefer strings.Builder over unsafebytes

### DIFF
--- a/bottom/bottom.go
+++ b/bottom/bottom.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"strings"
 	"unicode/utf8"
-
-	"github.com/nihaals/bottom-go/bottom/internal/unsafebytes"
 )
 
 const (
@@ -82,14 +80,14 @@ func calculateValueCharacters() [255]string {
 
 // Encode encodes a string in bottom
 func Encode(s string) string {
-	out := make([]byte, EncodedLen(s))
-	sum := 0
+	builder := strings.Builder{}
+	builder.Grow(EncodedLen(s))
 
 	for _, sChar := range []byte(s) {
-		sum += copy(out[sum:], valueCharacters[sChar])
+		builder.WriteString(valueCharacters[sChar])
 	}
 
-	return unsafebytes.String(out)
+	return builder.String()
 }
 
 // EncodedLen returns the length of the encoded string in exact.
@@ -190,7 +188,8 @@ func Decode(bottom string) (string, error) {
 		return "", errors.New("invalid bottom text")
 	}
 
-	buf := make([]byte, l)
+	builder := strings.Builder{}
+	builder.Grow(l)
 
 	var i int
 	for i < l {
@@ -199,12 +198,12 @@ func Decode(bottom string) (string, error) {
 			break
 		}
 
-		buf[i] = sumByte(bottom[:m])
+		builder.WriteByte(sumByte(bottom[:m]))
 		bottom = bottom[m+len(sectionSeparator):]
 		i++
 	}
 
-	return unsafebytes.String(buf), nil
+	return builder.String(), nil
 }
 
 // DecodeTo decodes the given bottom string into the given byte writer.

--- a/bottom/internal/unsafebytes/unsafebytes.go
+++ b/bottom/internal/unsafebytes/unsafebytes.go
@@ -1,9 +1,0 @@
-package unsafebytes
-
-import "unsafe"
-
-// String converts a byte slice to a string in an unsafe, non-copy fashion. It
-// works similarly to strings.Builder's String method.
-func String(bytes []byte) string {
-	return *(*string)(unsafe.Pointer(&bytes))
-}


### PR DESCRIPTION
This pull request removes the use of `unsafe` and instead prefers `strings.Builder`. This causes a slight performance loss during encoding and none during decoding:

```
# Old: unsafe
# New: strings.Builder

name          old time/op    new time/op    delta
Encode-8         276ns ±18%     292ns ± 3%  +5.61%  (p=0.010 n=15+15)
EncodeTo-8      1.87µs ± 3%    1.85µs ± 7%    ~     (p=0.056 n=13+15)
Decode-8        3.16µs ± 2%    3.18µs ± 7%    ~     (p=0.784 n=13+14)
DecodeFrom-8    3.74µs ± 4%    3.73µs ± 2%    ~     (p=0.562 n=15+13)

name          old speed      new speed      delta
Encode-8      43.0MB/s ±12%  41.1MB/s ± 3%  -4.38%  (p=0.018 n=14+15)
EncodeTo-8     175MB/s ± 3%   177MB/s ± 6%    ~     (p=0.060 n=13+15)
Decode-8       103MB/s ± 2%   103MB/s ± 6%    ~     (p=0.756 n=13+14)
DecodeFrom-8  87.4MB/s ± 4%  87.7MB/s ± 2%    ~     (p=0.563 n=15+13)

```